### PR TITLE
Fix issue #7

### DIFF
--- a/src/components/com_search/views/search/view.html.php
+++ b/src/components/com_search/views/search/view.html.php
@@ -150,7 +150,7 @@ class SearchViewSearch extends JViewLegacy
 			for ($i = 0, $count = count($results); $i < $count; ++$i)
 			{
 				$rowTitle = &$results[$i]->title;
-				$rowTitleHighLighted = $this->highLight($rowTitle, $needle, $searchWords);
+				$rowTitleHighLighted = $this->highLight($rowTitle, $needle, $searchWords, false);
 				$rowText = &$results[$i]->text;
 				$rowTextHighLighted = $this->highLight($rowText, $needle, $searchWords);
 
@@ -206,7 +206,7 @@ class SearchViewSearch extends JViewLegacy
 	 *
 	 * @since   3.8.4
 	 */
-	public function highLight($string, $needle, $searchWords)
+	public function highLight($string, $needle, $searchWords, $prepare=true)
 	{
 		$hl1            = '<span class="highlight">';
 		$hl2            = '</span>';
@@ -216,7 +216,9 @@ class SearchViewSearch extends JViewLegacy
 		// Doing HTML entity decoding here, just in case we get any HTML entities here.
 		$quoteStyle   = version_compare(PHP_VERSION, '5.4', '>=') ? ENT_NOQUOTES | ENT_HTML401 : ENT_NOQUOTES;
 		$row          = html_entity_decode($string, $quoteStyle, 'UTF-8');
-		$row          = SearchHelper::prepareSearchContent($row, $needle);
+		if($prepare) { 
+			$row  = SearchHelper::prepareSearchContent($row, $needle); 
+		}
 		$searchWords  = array_values(array_unique($searchWords));
 		$lowerCaseRow = $mbString ? mb_strtolower($row) : StringHelper::strtolower($row);
 


### PR DESCRIPTION
Pull Request for Issue #7 .

### Summary of Changes
Fixes the issue of apostrophes in article titles causing the title to be truncated in search results. 
Resolves #7
Resolves joomla/joomla-cms#34724

The truncation issue occurs in the `prepareSearchContent()` function in `SearchHelper` class. 
 Work around is to not run titles through search preparation which truncates text around the search term. Titles are returned in full instead, which is the expected behavior for search results (a user wants to see the title of an article not an extract of the title).


### Testing Instructions
Create articles with titles that contain and don't contain apostrophes:
"This title isn't ok"
"This title is ok"
"This isn't ok, this title really isn't ok"

Using com_search search page, search for the article using a keyword in the title or text eg ("ok")


### Expected result
The search results should show the full article titles, with search term highlighted
"This title isn't ok"
"This title is ok"
"This isn't ok, this title really isn't ok"


### Actual result
Before this patch the article title in the search results was truncated by one character for each apostrophe (in some cases the actual search term can be truncated, which is definitely not the expected behavior)
"This title isn't o" (truncated by 1 char)
"This title is ok" (not truncated)
"This isn't ok, this title really isn't" (truncated by 2 chars)


### Documentation Changes Required
None
